### PR TITLE
Label Changed  from  'Part Master Details' t…

### DIFF
--- a/src/constants/globalConstants.js
+++ b/src/constants/globalConstants.js
@@ -278,7 +278,7 @@ export const componentList = [
       {
         iconPath: partIcon,
         id: "UI 22 010",
-        label: "Part Master Details ",
+        label: "Capital Asset Details ",
         path: "/partInfo",
         href: "/operationGame/partInfo",
         routeElement: <PartInfo />


### PR DESCRIPTION
…o 
For UI Screen UI 22 010,  Label Changed  from  'Part Master Details' to 'Capital Asset Details' 
Now the List is restricted to Capital Assets only - in line with API Call UI_Part_mst_Info