### PR TITLE
UI Menu Pages: Check by Page UI_Id, instead of label

### DIFF
--- a/src/pages/BatchMgt/BatchMgt.jsx
+++ b/src/pages/BatchMgt/BatchMgt.jsx
@@ -13,7 +13,8 @@ function BatchMgt() {
         navigate(href);
     };
 
-    const BatchMgtItem = userAccessiblePages?.find(item => item.label === 'Batch Management');
+    // const BatchMgtItem = userAccessiblePages?.find(item => item.label === 'Batch Management');
+    const BatchMgtItem = userAccessiblePages?.find(item => item.id === 'UI 99 970');
     const children = BatchMgtItem ? BatchMgtItem.children : [];
 
     return (

--- a/src/pages/GameDashboard/GameDashboard.jsx
+++ b/src/pages/GameDashboard/GameDashboard.jsx
@@ -34,7 +34,8 @@ function GameDashboard() {
   });
 
   // Find the "Game Dashboard" item and get its children
-  const gameDashboardItem = componentList.find(item => item.label === 'Game Dashboard');
+  //const gameDashboardItem = componentList.find(item => item.label === 'Game Dashboard');
+  const gameDashboardItem = componentList.find(item => item.id === 'UI 99 900');
   const children = gameDashboardItem ? gameDashboardItem.children : [];
 
   useEffect(() => {

--- a/src/pages/InfoDesk/InfoDesk.jsx
+++ b/src/pages/InfoDesk/InfoDesk.jsx
@@ -12,8 +12,8 @@ function InfoDesk() {
     const handleCardClick = (href) => {
         navigate(href);
     };
-
-    const infoDeskItem = userAccessiblePages?.find(item => item.label === 'Info Desk');
+   // const infoDeskItem = userAccessiblePages?.find(item => item.label === 'Information Desk');
+    const infoDeskItem = userAccessiblePages?.find(item => item.id === 'UI 99 910');
     const children = infoDeskItem ? infoDeskItem.children : [];
 
     return (

--- a/src/pages/MarketScenario/MarketScenario.jsx
+++ b/src/pages/MarketScenario/MarketScenario.jsx
@@ -12,8 +12,8 @@ function MarketScenario() {
     const handleCardClick = (href) => {
         navigate(href);
     };
-
-    const infoDeskItem = userAccessiblePages?.find(item => item.label === 'Market Scenario');
+    //const infoDeskItem = userAccessiblePages?.find(item => item.label === 'Market Scenario');
+    const infoDeskItem = userAccessiblePages?.find(item => item.id === 'UI 99 920');
     const children = infoDeskItem ? infoDeskItem.children : [];
 
     return (

--- a/src/pages/Operations/Operations.jsx
+++ b/src/pages/Operations/Operations.jsx
@@ -13,7 +13,8 @@ function Operations() {
         navigate(href);
     };
 
-    const infoDeskItem = userAccessiblePages?.find(item => item.label === 'Operations');
+    //const infoDeskItem = userAccessiblePages?.find(item => item.label === 'Operations');
+    const infoDeskItem = userAccessiblePages?.find(item => item.id === 'UI 99 930');
     const children = infoDeskItem ? infoDeskItem.children : [];
 
     return (

--- a/src/pages/Simulation/Simulation.jsx
+++ b/src/pages/Simulation/Simulation.jsx
@@ -12,8 +12,9 @@ function Simulation() {
     const handleCardClick = (href) => {
         navigate(href);
     };
-
-    const SimulationItem = userAccessiblePages?.find(item => item.label === 'Simulation');
+    
+    //const SimulationItem = userAccessiblePages?.find(item => item.label === 'Simulation');
+    const SimulationItem = userAccessiblePages?.find(item => item.id === 'UI 99 940');
     const children = SimulationItem ? SimulationItem.children : [];
 
     return (

--- a/src/pages/SystemInfoDesk/SystemInfoDesk.jsx
+++ b/src/pages/SystemInfoDesk/SystemInfoDesk.jsx
@@ -12,8 +12,9 @@ function SystemInfoDesk() {
     const handleCardClick = (href) => {
         navigate(href);
     };
-
-    const SystemInfoDeskItem = userAccessiblePages?.find(item => item.label === 'System Info Desk');
+    
+    //const SystemInfoDeskItem = userAccessiblePages?.find(item => item.label === 'System Info Desk');
+    const SystemInfoDeskItem = userAccessiblePages?.find(item => item.id === 'UI 99 990');
     const children = SystemInfoDeskItem ? SystemInfoDeskItem.children : [];
 
     return (

--- a/src/pages/UserMgtDesk/UserMgtDesk.jsx
+++ b/src/pages/UserMgtDesk/UserMgtDesk.jsx
@@ -13,7 +13,8 @@ function UserMgtDesk() {
         navigate(href);
     };
 
-    const UserMgtDeskItem = userAccessiblePages?.find(item => item.label === 'User Mgt Desk');
+    //const UserMgtDeskItem = userAccessiblePages?.find(item => item.label === 'User Mgt Desk');
+    const UserMgtDeskItem = userAccessiblePages?.find(item => item.id === 'UI 99 980');
     const children = UserMgtDeskItem ? UserMgtDeskItem.children : [];
 
     return (


### PR DESCRIPTION
For al MENU Items:
Changed checking of Menu Item from .label to UI_Id, as in API getUserAccessPageId
Label Name may be changed and it does not affect rendering.

Test: OKAY
App opened in browser.
All menu items are displayed and accessible
Children under each are clickable